### PR TITLE
default url prefix HTTPS, default action is login

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -40,12 +40,12 @@ import { OAuth2Strategy, InternalOAuthError } from 'passport-oauth';
 export class BullhornOAuthStrategy extends OAuth2Strategy {
     constructor(options, verify) {
         options = options || {};
-        options.authorizationURL = options.authorizationURL || 'http://rest.bullhornstaffing.com/oauth/authorize';
-        options.tokenURL = options.tokenURL || 'http://rest.bullhornstaffing.com/oauth/token';
+        options.authorizationURL = options.authorizationURL || 'https://rest.bullhornstaffing.com/oauth/authorize?action=Login';
+        options.tokenURL = options.tokenURL || 'https://rest.bullhornstaffing.com/oauth/token';
 
         super(options, verify);
         this.name = 'bullhorn';   
-        this.profileURL = options.profileURL || 'http://rest.bullhorn.com/rest-services/login?version=*';
+        this.profileURL = options.profileURL || 'https://rest.bullhorn.com/rest-services/login?version=*';
     }
     
     /**


### PR DESCRIPTION
All non HTTPS requests are refused or blank. Can be overridden however the defaults should work now. 
When using passport to login silently in the background it will always refuse the connection or throw an error. Setting this to login allows you to login in the background and receive the tokens in the callback.
Thanks